### PR TITLE
Allow adding response headers in exceptions

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -184,7 +184,7 @@ class WSGI:
 
         except errors.HTTPError as err:
             self.response.status_code = err.status_code
-            headers = [("Content-Type", "application/json")]
+            headers = [("Content-Type", "application/json")] + err.headers
             self.start(self.response.status, headers)
             resp = err.response()
     

--- a/pycnic/errors.py
+++ b/pycnic/errors.py
@@ -8,14 +8,18 @@ class HTTPError(PycnicError):
     status = None
     message = None
     data = None
+    headers = None
 
-    def __init__(self, status_code, message, data=None):
+    def __init__(self, status_code, message, data=None, headers=[]):
         if self.status_code:
             status_code = self.status_code
         self.status_code = status_code
         self.status = STATUSES[status_code]
         self.message = message
         self.data = data
+        if self.headers:
+            headers = self.headers
+        self.headers = headers
 
     def response(self):
         return { 


### PR DESCRIPTION
This adds support for adding response headers inside HTTPError exceptions.

**Example:**

In my mock AWS Lambda API I'm adding a unique request id to the response and the type of exception:

```python
class UserError(HTTPError):

    status_code = 400
    error_namespace = ':http://internal.amazon.com/coral/com.amazonaws.awsgirapi/'

    def __init__(self, message):
        self.message = message
        self.headers = [
            ('x-amzn-requestid', str(uuid1())),
            ('x-amzn-errortype', self.__class__.__name__ + self.error_namespace)
        ]

    def response(self):
        return {
            "Type": "User",
            "Message": self.message
        }

class InvalidRequestContentException(UserError):

    status_code = 400

class ResourceNotFoundException(UserError):

    status_code = 404

```

```http
HTTP/1.1 400 Bad Request
Connection: close
Content-Type: application/json
Date: Sat, 14 May 2016 15:03:33 GMT
Server: gunicorn/19.5.0
Transfer-Encoding: chunked
x-amzn-errortype: InvalidRequestContentException:http://internal.amazon.com/coral/com.amazonaws.awsgirapi/
x-amzn-requestid: 06c50994-19e5-11e6-82dc-a45e60de2283

{
    "Message": "Client context must be a valid Base64-encoded JSON object.",
    "Type": "User"
}
```