### PR TITLE
Split debug traceback into array for readability

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -193,7 +193,7 @@ class WSGI:
             headers = [("Content-Type", "application/json")]
             self.start(STATUSES[500], headers)
             if self.debug:
-                resp = { "error": traceback.format_exc()}
+                resp = { "error": traceback.format_exc().split("\n")}
             else:
                 resp = { "error": "Internal server error encountered." }
             


### PR DESCRIPTION
This makes it much easier to read tracebacks, when using a client that prettifies the response, like httpie.

Without this change I found it very hard to read tracebacks, because they were displayed as one long string.

**Example output after change:**

```http
HTTP/1.1 500 Internal Server Error
Connection: close
Content-Type: application/json
Date: Sat, 14 May 2016 03:16:35 GMT
Server: gunicorn/19.5.0
Transfer-Encoding: chunked

{
    "error": [
        "Traceback (most recent call last):",
        "  File \"/usr/local/lib/python2.7/site-packages/pycnic/core.py\", line 184, in __iter__",
        "    resp = self.delegate()",
        "  File \"/usr/local/lib/python2.7/site-packages/pycnic/core.py\", line 232, in delegate",
        "    output = func(*args)",
        "  File \"/Users/felix/dev/misc/py-lambda-image-toaster/lambda_server.py\", line 122, in post",
        "    encoded_log = base64.b64encode(log.read())",
        "NameError: global name 'base64' is not defined",
        ""
    ]
}
```