### PR TITLE
Add method to access request headers

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -28,6 +28,10 @@ class Request(object):
         self.path = path
         self.method = method.upper()
         self.environ = environ
+
+    def get_header(self, name, default=None):
+        wsgi_name = 'HTTP_' + name.upper().replace('-', '_')
+        return self.environ.get(wsgi_name, default)
     
     @property
     def args(self):


### PR DESCRIPTION
This allows to retrieve headers with a fallback value using:

```python
self.request.get_header('X-Foo', default='Bar')
```

Which is much nicer than retrieving through the WSGI environment:

```python
self.request.environ.get('HTTP_X_FOO', 'Bar')
```

It does not currently handle accessing headers that are not prefixed by 'HTTP_' in the WSGI environment, like 'Content-Type' and 'Content-Length', but that would be easy to add.