### PR TITLE
Use PID to kill gunicorn

### DIFF
--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -2,18 +2,17 @@
 
 output="Test results:\n"
 
-for app in bobo_test falcon_test pycnic_test cherrypy_test pyramid_test hug_test flask_test bottle_test; 
+for app in bobo_test falcon_test pycnic_test cherrypy_test pyramid_test hug_test flask_test bottle_test;
 do
     echo "TEST: $app"
     gunicorn -w 3 $app:app &
-    sleep 2 
-    ab_out=`ab -n 5000 -c 5 http://localhost:8000/json`
-    killall gunicorn
+    gunicorn_pid=$!
+    sleep 2
+    ab_out=`ab -n 5000 -c 5 http://127.0.0.1:8000/json`
+    kill $gunicorn_pid
     rps=`echo "$ab_out" | grep "Requests per second"`
     crs=`echo "$ab_out" | grep "Complete requests"`
     output="$output\n$app:\n\t$rps\n\t$crs"
 done
 
 echo -e "$output"
-
-


### PR DESCRIPTION
This seems better than killing all processes named gunicorn. I also use the local IP address `127.0.0.1` instead of `localhost` because that didn't work on my machine for some reason.