### PR TITLE
Run tornado test with gunicorn and more processes

### DIFF
--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -2,10 +2,15 @@
 
 output="Test results:\n"
 
-for app in bobo_test falcon_test pycnic_test cherrypy_test pyramid_test hug_test flask_test bottle_test;
+for app in bobo_test falcon_test pycnic_test cherrypy_test pyramid_test hug_test flask_test bottle_test tornado_test;
 do
     echo "TEST: $app"
-    gunicorn -w 3 $app:app &
+    if [ "$app" = "tornado_test" ]; then
+	worker="tornado"
+    else
+	worker="sync"
+    fi
+    gunicorn -w 3 -k $worker $app:app &
     gunicorn_pid=$!
     sleep 2
     ab_out=`ab -n 5000 -c 5 http://127.0.0.1:8000/json`

--- a/benchmark/tornado_test.py
+++ b/benchmark/tornado_test.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 import tornado.ioloop
 import tornado.web
-import json
 
 class JSONHandler(tornado.web.RequestHandler):
     def get(self):
         self.write({"message":"Hello, world!"})
 
-application = tornado.web.Application([
+app = tornado.web.Application([
     (r"/json", JSONHandler),
 ])
 
 if __name__ == "__main__":
-    application.listen(8000)
+    app.listen(8000)
     tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
Gunicorn has had a worker class for Tornado applications for quite some time. I was wondering why the benchmarks made Tornado look so slow, so looked through them and found that it's running as a single process whereas the WSGI ones are not. This change makes the comparison a bit more fair.

It looks like it's also [possible](https://aiohttp.readthedocs.io/en/stable/gunicorn.html) to use gunicorn with Muffin, too.