### PR TITLE
Dump lists to JSON

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -221,7 +221,7 @@ class WSGI:
             else:
                 resp = { "error": "Internal server error encountered." }
             
-        if isinstance(resp, dict):
+        if isinstance(resp, (dict, list)):
             if self.debug:
                 jresp = json.dumps(resp, indent=4)
             else:


### PR DESCRIPTION
As for now, if response is a list, it isn't converted to JSON, so e. g. trying to return directly this response:
```
[
    {"id":1},
    {"where":"in my house"}
]
```
fails, because WSGI server doesn't expect list of dicts. This commit fixes this by dumping lists as well as dicts.