### PR TITLE
Added decorator for running request validations before actual handling

### DIFF
--- a/examples/validation.py
+++ b/examples/validation.py
@@ -1,0 +1,28 @@
+from pycnic.core import Handler, WSGI
+from pycnic.utils import requires_validation
+
+
+def has_proper_name(data):
+    if 'name' not in data or data['name'] != 'root':
+        raise ValueError('Expected \'root\' as name')
+
+
+class NameHandler(Handler):
+
+    @requires_validation(has_proper_name)
+    def post(self):
+        return {'status': 'ok'}
+
+
+class app(WSGI):
+    routes = [('/name', NameHandler())]
+
+if __name__ == "__main__":
+
+    from wsgiref.simple_server import make_server
+    try:
+        print("Serving on 0.0.0.0:8080...")
+        make_server('0.0.0.0', 8080, app).serve_forever()
+    except KeyboardInterrupt:
+        pass
+    print("Done")

--- a/pycnic/utils.py
+++ b/pycnic/utils.py
@@ -1,5 +1,8 @@
 import json
 import sys
+from functools import wraps
+
+from . import errors
 
 if sys.version_info >= (3, 0):
     from urllib.parse import parse_qsl
@@ -21,3 +24,24 @@ def query_string_to_json(qs):
         return {}
     data = query_string_to_dict(qs)
     return json.loads(data.get("json","{}"))
+
+
+def requires_validation(validator, with_route_params=False):
+    """ Validates an incoming request over given validator. If with_route_params is set to True,
+    validator is called with request data and args taken from route, otherwise only request data is
+    passed to validator. If validator raises any Exception, HTTP_400 is raised.
+    """
+    def wrapper(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            try:
+                if with_route_params:
+                    validator(args[0].request.data, args[1:])
+                else:
+                    validator(args[0].request.data)
+            except Exception as e:
+                raise errors.HTTP_400(str(e))
+
+            return f(*args, **kwargs)
+        return wrapped
+    return wrapper


### PR DESCRIPTION
This pull request provides simple way to add request validations in context of single route. A decorator `@requires_validation` is added to `pycnic.utils` that if given validator raises any exception when called with request payload (and optionally args taken from route), then HTTP 400 Bad Request is raised. I also created a simple example how to use the validation decorator.