### PR TITLE
Default OPTIONS handler

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -33,7 +33,12 @@ class Handler(object):
             'patch'
         ]
 
-        supported_methods = [method.upper() for method in http_methods if method in dir(self)]
+        supported_methods = []
+
+        for method in http_methods:
+            if method in dir(self):
+                supported_methods.append(method.upper())
+
         self.response.set_header('Allow', ', '.join(supported_methods))
         return {}
 
@@ -51,7 +56,7 @@ class Request(object):
         self.path = path
         self.method = method.upper()
         self.environ = environ
-    
+
     def get_header(self, name, default=None):
         return self.headers.get(name.title(), default)
 
@@ -84,12 +89,12 @@ class Request(object):
 
         try:
             qs = self.environ["QUERY_STRING"]
-            self._json_args = utils.query_string_to_json(qs) 
+            self._json_args = utils.query_string_to_json(qs)
         except Exception:
-            raise errors.HTTP_400("Invalid JSON in request query string") 
+            raise errors.HTTP_400("Invalid JSON in request query string")
 
         return self._json_args
- 
+
     @property
     def body(self):
         if self._body is not None:
@@ -116,7 +121,7 @@ class Request(object):
             for cookie_line in self.environ['HTTP_COOKIE'].split(';'):
                 if "DELETED" in cookie_line:
                     continue
-                cname, cvalue = cookie_line.strip().split('=',1)
+                cname, cvalue = cookie_line.strip().split('=', 1)
                 self._cookies[cname] = cvalue
 
         return self._cookies
@@ -142,11 +147,11 @@ class Request(object):
         except KeyError:
             return self.environ['REMOTE_ADDR']
 
+
 class Response(object):
-    
 
     def __init__(self, status_code):
-        self.header_dict = { 
+        self.header_dict = {
             "Content-Type": "application/json"
         }
         self._headers = []
@@ -158,33 +163,35 @@ class Response(object):
 
     def set_cookie(
             self, key, value, expires="", path='/', domain="", flags=[]):
-        value = value.replace(";","") # ; not allowed
+        value = value.replace(";", "")  # ; not allowed
         if expires:
-            expires = "expires=%s; "%(expires)
+            expires = "expires=%s; " % (expires)
         if domain:
-            domain = "Domain=%s; "%(domain)
+            domain = "Domain=%s; " % (domain)
 
         self.cookie_dict[key] = "%s;%s%s path=%s; %s"\
-            %(value, domain, expires, path, "; ".join(flags))
-        
+            % (value, domain, expires, path, "; ".join(flags))
+
     def delete_cookie(self, key):
-        self.set_cookie(key, "DELETED", expires="Thu, 01 Jan 1970 00:00:00 GMT")
+        expiry_string = 'Thu, 01 Jan 1970 00:00:00 GMT'
+        self.set_cookie(key, "DELETED", expires=expiry_string)
 
     @property
     def headers(self):
         self._headers = []
-        for k,v in self.header_dict.items():
+        for k, v in self.header_dict.items():
             self._headers.append((k, v))
-        for k,v in self.cookie_dict.items():
-            self._headers.append(('Set-Cookie', '%s=%s'%(k,v)))
+        for k, v in self.cookie_dict.items():
+            self._headers.append(('Set-Cookie', '%s=%s' % (k, v)))
         return self._headers
 
     @property
     def status(self):
         if self.status_code in STATUSES:
             return STATUSES[self.status_code]
-        print("Warning! Status %s does not exist!"%(self.status_code))
+        print("Warning! Status %s does not exist!" % (self.status_code))
         return STATUSES[577]
+
 
 class WSGI:
 
@@ -197,7 +204,7 @@ class WSGI:
     headers = None
     strip_path = True
     json_cls = None
-        
+
     def __init__(self, environ, start_response):
 
         if not self.logger:
@@ -215,15 +222,12 @@ class WSGI:
             environ=environ
         )
 
-        self.response = Response(
-            status_code = 200
-        )
+        self.response = Response(status_code=200)
 
         self.environ = environ
         self.start = start_response
         self.response.set_header("Content-Type", "application/json")
-       
-            
+
     def __iter__(self):
         try:
             if self.before:
@@ -245,32 +249,32 @@ class WSGI:
                 headers += err.headers
             self.start(self.response.status, headers)
             resp = err.response()
-    
+
         except Exception as err:
             self.logger.exception(err)
             headers = [("Content-Type", "application/json")]
             self.start(STATUSES[500], headers)
             if self.debug:
-                resp = { "error": traceback.format_exc().split("\n")}
+                resp = {"error": traceback.format_exc().split("\n")}
             else:
-                resp = { "error": "Internal server error encountered." }
+                resp = {"error": "Internal server error encountered."}
 
         if self.teardown:
             self.teardown()
-            
+
         if isinstance(resp, (dict, list)):
             try:
                 if self.debug:
                     jresp = json.dumps(resp, indent=4, cls=self.json_cls)
                 else:
                     jresp = json.dumps(resp, cls=self.json_cls)
-            except Exception as err:
+            except Exception:
                 if self.debug:
                     msg = traceback.format_exc().split("\n")
-                    jresp = json.dumps({ "error": msg }, indent=4)
+                    jresp = json.dumps({"error": msg}, indent=4)
                 else:
                     msg = "An unhandled exception occured during response"
-                    jresp = json.dumps({ "error": msg })
+                    jresp = json.dumps({"error": msg})
             self.logger.debug("Sending JSON response: %s", jresp)
             return iter([jresp.encode('utf-8')])
         elif isinstance(resp, str):
@@ -283,7 +287,7 @@ class WSGI:
     def delegate(self):
         path = self.request.path
         method = self.request.method
-                
+
         for pattern, handler in self.routes:
             # Set defaults for handler
             handler.request = self.request
@@ -299,7 +303,7 @@ class WSGI:
                 try:
                     func = getattr(handler, funcname)
                 except AttributeError:
-                    raise errors.HTTP_405("%s not allowed"%(method.upper()))
+                    raise errors.HTTP_405("%s not allowed" % (method.upper()))
 
                 output = func(*args)
 
@@ -307,7 +311,5 @@ class WSGI:
                     handler.after()
 
                 return output
-                               
-        raise errors.HTTP_404("Path %s not found"%(path))
 
-
+        raise errors.HTTP_404("Path %s not found" % (path))

--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -12,7 +12,30 @@ from . import errors
 class Handler(object):
 
     request = None
-    response = None 
+    response = None
+
+    def options(self):
+        """Default implementation of OPTIONS method.
+
+        Checks which methods are implemented, and sets the Allow header
+        accordingly.
+        """
+        # Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+        http_methods = [
+            'get',
+            'head',
+            'post',
+            'put',
+            'delete',
+            'connect',
+            'options',
+            'trace',
+            'patch'
+        ]
+
+        supported_methods = [method.upper() for method in http_methods if method in dir(self)]
+        self.response.set_header('Allow', ', '.join(supported_methods))
+        return {}
 
 
 class Request(object):

--- a/pycnic/data.py
+++ b/pycnic/data.py
@@ -55,5 +55,3 @@ STATUSES = {
         510: "510 Not Extended",
         577: "577 Unknown Status",
 }
-
-

--- a/pycnic/errors.py
+++ b/pycnic/errors.py
@@ -1,7 +1,9 @@
 from .data import STATUSES
 
+
 class PycnicError(Exception):
     pass
+
 
 class HTTPError(PycnicError):
     status_code = 0
@@ -21,15 +23,18 @@ class HTTPError(PycnicError):
             self.headers = headers
 
     def response(self):
-        return { 
+        return {
             "status": self.status,
             "status_code": self.status_code,
-            "error":self.message,
-            "data":self.data
+            "error": self.message,
+            "data": self.data
         }
 
+
 class HTTPNumeric(HTTPError):
+
     status_code = 0
+
     def __init__(self, message, data=None, headers=[]):
         super(HTTPError, self).__init__(self.status_code, message, data, headers)
         self.status = STATUSES[self.status_code]
@@ -37,23 +42,30 @@ class HTTPNumeric(HTTPError):
         self.data = data
         self.headers = headers
 
+
 class HTTP_400(HTTPNumeric):
     status_code = 400
+
 
 class HTTP_401(HTTPNumeric):
     status_code = 401
 
+
 class HTTP_403(HTTPNumeric):
     status_code = 403
 
+
 class HTTP_404(HTTPNumeric):
     status_code = 404
-    
+
+
 class HTTP_405(HTTPNumeric):
     status_code = 405
 
+
 class HTTP_408(HTTPNumeric):
     status_code = 408
+
 
 class HTTP_500(HTTPNumeric):
     status_code = 500

--- a/pycnic/utils.py
+++ b/pycnic/utils.py
@@ -9,6 +9,7 @@ if sys.version_info >= (3, 0):
 else:
     from cgi import parse_qsl
 
+
 def query_string_to_dict(qs):
     """ Returns a dictionary from a QUERY_STRING """
 
@@ -17,17 +18,18 @@ def query_string_to_dict(qs):
         return dict(pairs)
     return {}
 
+
 def query_string_to_json(qs):
     """ Returns a dictionary from a QUERY_STRING with JSON in it """
 
     if "json=" not in qs:
         return {}
     data = query_string_to_dict(qs)
-    return json.loads(data.get("json","{}"))
+    return json.loads(data.get("json", "{}"))
 
 
 def requires_validation(validator, with_route_params=False):
-    """ Validates an incoming request over given validator. 
+    """ Validates an incoming request over given validator.
     If with_route_params is set to True, validator is called with request
     data and args taken from route, otherwise only request data is
     passed to validator. If validator raises any Exception, HTTP_400 is raised.


### PR DESCRIPTION
During certain AJAX requests in a browser, it is standard behavior to send a preflight OPTIONS request to the server to check if the request about to be made is supported by the server. This PR implements a default `options` method in the `pycnic.core.Handler` class to save implementation time for the user. It checks which HTTP methods are implemented by the class, creates a list of them, and sends that list in the `Allow` response header. The [relevant RFC](https://tools.ietf.org/html/rfc7231#section-4.3.7) does not specify what the body of an OPTIONS response should contain, so this implementation returns an empty json object, to be in-line with the rest of the library.

I've also taken this chance to fix a number of complaints from flake8 about various whitespace issues, as well as one or two instances of a line being too long.