### PR TITLE
Add *args and **kwargs to default options method

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -14,7 +14,7 @@ class Handler(object):
     request = None
     response = None
 
-    def options(self):
+    def options(self, *args, **kwargs):
         """Default implementation of OPTIONS method.
 
         Checks which methods are implemented, and sets the Allow header


### PR DESCRIPTION
The default options() method doesn't handle routes that have arguments (e.g. `/path/to/my/(regex)`). This corrects for that issue