### PR TITLE
Quick fix for #35 - QUERY_STRING

### DIFF
--- a/pycnic/core.py
+++ b/pycnic/core.py
@@ -78,7 +78,7 @@ class Request(object):
     def args(self):
         if self._args is not None:
             return self._args
-        qs = self.environ["QUERY_STRING"]
+        qs = self.environ.get("QUERY_STRING", "")
         self._args = utils.query_string_to_dict(qs)
         return self._args
 
@@ -88,7 +88,7 @@ class Request(object):
             return self._json_args
 
         try:
-            qs = self.environ["QUERY_STRING"]
+            qs = self.environ.get("QUERY_STRING", "")
             self._json_args = utils.query_string_to_json(qs)
         except Exception:
             raise errors.HTTP_400("Invalid JSON in request query string")


### PR DESCRIPTION
Addresses an issue with some servers not specifying `QUERY_STRING` in environment as opposed to specifying as an empty string. 